### PR TITLE
fix: move reagents and reactions list generation to proper proc, generate disease archive after reagents generation, fix float indexes in cure generation

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -140,18 +140,35 @@
 		if(initial(D.name))
 			GLOB.keybindings += new path()
 
-/* // Uncomment to debug chemical reaction list.
-/client/verb/debug_chemical_list()
+	// Init chemical reagents
+	init_datum_subtypes(/datum/reagent, GLOB.chemical_reagents_list, null, "id")
 
-	for(var/reaction in GLOB.chemical_reactions_list)
-		. += "GLOB.chemical_reactions_list\[\"[reaction]\"\] = \"[GLOB.chemical_reactions_list[reaction]]\"\n"
-		if(islist(GLOB.chemical_reactions_list[reaction]))
-			var/list/L = GLOB.chemical_reactions_list[reaction]
-			for(var/t in L)
-				. += "    has: [t]\n"
-	to_chat(world, .)
-*/
+	// Chemical Reactions - Initialises all /datum/chemical_reaction into an assoc list of: reagent -> list of chemical reactions
+	// For example:
+	// chemical_reaction_list["plasma"] is a list of all reactions relating to plasma
+	for(var/path in subtypesof(/datum/chemical_reaction))
+		var/datum/chemical_reaction/reaction_datum = new path()
+		if(!length(reaction_datum?.required_reagents))
+			continue
 
+		for(var/reagent in reaction_datum.required_reagents)
+			if(!GLOB.chemical_reactions_list[reagent])
+				GLOB.chemical_reactions_list[reagent] = list()
+			GLOB.chemical_reactions_list[reagent] += reaction_datum
+
+	// Init disease archive
+	GLOB.archive_diseases += list(
+		"sneeze" = new /datum/disease/advance/preset/cold(),
+		"cough" = new /datum/disease/advance/preset/flu(),
+		"voice_change" = new /datum/disease/advance/preset/voice_change(),
+		"heal" = new /datum/disease/advance/preset/heal(),
+		"hallucigen" = new /datum/disease/advance/preset/hullucigen(),
+		"sensory_restoration" = new /datum/disease/advance/preset/sensory_restoration(),
+		"mind_restoration" = new /datum/disease/advance/preset/mind_restoration(),
+		"damage_converter:heal:viralevolution" = new /datum/disease/advance/preset/advanced_regeneration(),
+		"dizzy:flesh_eating:viraladaptation:youth" = new /datum/disease/advance/preset/stealth_necrosis(),
+		"beard:itching:voice_change" = new /datum/disease/advance/preset/pre_kingstons()
+	)
 
 //creates every subtype of prototype (excluding prototype) and adds it to list L.
 //if no list/L is provided, one is created.

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -148,7 +148,7 @@
 	// chemical_reaction_list["plasma"] is a list of all reactions relating to plasma
 	for(var/path in subtypesof(/datum/chemical_reaction))
 		var/datum/chemical_reaction/reaction_datum = new path()
-		if(!length(reaction_datum?.required_reagents))
+		if(!length(reaction_datum.required_reagents))
 			continue
 
 		for(var/reagent in reaction_datum.required_reagents)

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -1,7 +1,7 @@
 GLOBAL_LIST_INIT(portals, list())					//for use by portals
 GLOBAL_LIST(cable_list)								//Index for all cables, so that powernets don't have to look through the entire world all the time
-GLOBAL_LIST(chemical_reactions_list)			//list of all /datum/chemical_reaction datums. Used during chemical reactions
-GLOBAL_LIST(chemical_reagents_list)				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff
+GLOBAL_LIST_EMPTY(chemical_reactions_list)			//list of all /datum/chemical_reaction datums. Used during chemical reactions
+GLOBAL_LIST_EMPTY(chemical_reagents_list)				//list of all /datum/reagent datums indexed by reagent id. Used by chemistry stuff
 GLOBAL_LIST_INIT(landmarks_list, list())				//list of all landmarks created
 GLOBAL_LIST_INIT(surgery_steps, list())				//list of all surgery steps  |BS12
 GLOBAL_LIST_INIT(side_effects, list())				//list of all medical sideeffects types by thier names |BS12

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -15,18 +15,7 @@ GLOBAL_LIST_INIT(advance_cures, list(
 									"silver", "gold"
 ))
 
-GLOBAL_LIST_INIT(archive_diseases, list(
-	"sneeze" = new /datum/disease/advance/preset/cold(),
-	"cough" = new /datum/disease/advance/preset/flu(),
-	"voice_change" = new /datum/disease/advance/preset/voice_change(),
-	"heal" = new /datum/disease/advance/preset/heal(),
-	"hallucigen" = new /datum/disease/advance/preset/hullucigen(),
-	"sensory_restoration" = new /datum/disease/advance/preset/sensory_restoration(),
-	"mind_restoration" = new /datum/disease/advance/preset/mind_restoration(),
-	"damage_converter:heal:viralevolution" = new /datum/disease/advance/preset/advanced_regeneration(),
-	"dizzy:flesh_eating:viraladaptation:youth" = new /datum/disease/advance/preset/stealth_necrosis(),
-	"beard:itching:voice_change" = new /datum/disease/advance/preset/pre_kingstons()
-))
+GLOBAL_LIST_EMPTY(archive_diseases)
 
 /*
 
@@ -257,16 +246,11 @@ GLOBAL_LIST_INIT(archive_diseases, list(
 // Will generate a random cure, the less resistance the symptoms have, the harder the cure.
 /datum/disease/advance/proc/GenerateCure(list/properties = list())
 	if(properties && properties.len)
-		var/res = clamp(properties["resistance"] - (symptoms.len / 2), 1, GLOB.advance_cures.len)
-		cures = list(GLOB.advance_cures[res])
-		cure_text = GLOB.advance_cures[res]
+		var/res = round(clamp(properties["resistance"] - (symptoms.len / 2), 1, GLOB.advance_cures.len))
 
 		// Get the cure name from the cure_id
-		var/datum/reagent/D = GLOB.chemical_reagents_list[cures[1]]
+		var/datum/reagent/D = GLOB.chemical_reagents_list[GLOB.advance_cures[res]]
 		cure_text = D.name
-
-
-	return
 
 // Randomly generate a symptom, has a chance to lose or gain a symptom.
 /datum/disease/advance/proc/Evolve(min_level, max_level)

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -245,12 +245,13 @@ GLOBAL_LIST_EMPTY(archive_diseases)
 
 // Will generate a random cure, the less resistance the symptoms have, the harder the cure.
 /datum/disease/advance/proc/GenerateCure(list/properties = list())
-	if(properties && properties.len)
-		var/res = round(clamp(properties["resistance"] - (symptoms.len / 2), 1, GLOB.advance_cures.len))
+	if(length(properties))
+		var/res = round(clamp(properties["resistance"] - (symptoms.len / 2), 1, length(GLOB.advance_cures)))
+		cures = list(GLOB.advance_cures[res])
 
 		// Get the cure name from the cure_id
-		var/datum/reagent/D = GLOB.chemical_reagents_list[GLOB.advance_cures[res]]
-		cure_text = D.name
+		var/datum/reagent/cure = GLOB.chemical_reagents_list[cures[1]]
+		cure_text = cure.name
 
 // Randomly generate a symptom, has a chance to lose or gain a symptom.
 /datum/disease/advance/proc/Evolve(min_level, max_level)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -21,38 +21,6 @@
 		temperature_min = temperature_minimum
 	if(temperature_maximum)
 		temperature_max = temperature_maximum
-	//I dislike having these here but map-objects are initialised before world/New() is called. >_>
-	if(!GLOB.chemical_reagents_list)
-		//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
-		var/paths = subtypesof(/datum/reagent)
-		GLOB.chemical_reagents_list = list()
-		for(var/path in paths)
-			var/datum/reagent/D = new path()
-			GLOB.chemical_reagents_list[D.id] = D
-	if(!GLOB.chemical_reactions_list)
-		//Chemical Reactions - Initialises all /datum/chemical_reaction into a list
-		// It is filtered into multiple lists within a list.
-		// For example:
-		// chemical_reaction_list["plasma"] is a list of all reactions relating to plasma
-
-		var/paths = subtypesof(/datum/chemical_reaction)
-		GLOB.chemical_reactions_list = list()
-
-		for(var/path in paths)
-
-			var/datum/chemical_reaction/D = new path()
-			var/list/reaction_ids = list()
-
-			if(D && length(D.required_reagents))
-				for(var/reaction in D.required_reagents)
-					reaction_ids += reaction
-
-			// Create filters based on each reagent id in the required reagents list
-			for(var/id in reaction_ids)
-				if(!GLOB.chemical_reactions_list[id])
-					GLOB.chemical_reactions_list[id] = list()
-				GLOB.chemical_reactions_list[id] += D
-				break // Don't bother adding ourselves to other reagent ids, it is redundant.
 
 /datum/reagents/proc/remove_any(amount = 1)
 	var/list/cached_reagents = reagent_list

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -72,15 +72,21 @@
 	..()
 	if(!possible_transfer_amounts)
 		verbs -= /obj/item/reagent_containers/verb/set_APTFT
-	if(spawned_disease)
-		var/datum/disease/F = new spawned_disease
-		var/list/data = list("viruses" = list(F), "blood_color" = "#A10808")
-		reagents.add_reagent("blood", disease_amount, data)
 	add_initial_reagents()
+
+/obj/item/reagent_containers/Initialize(mapload)
+	. = ..()
+	add_spawned_disease()
 
 /obj/item/reagent_containers/proc/add_initial_reagents()
 	if(list_reagents)
 		reagents.add_reagent_list(list_reagents)
+
+/obj/item/reagent_containers/proc/add_spawned_disease()
+	if(spawned_disease)
+		var/datum/disease/F = new spawned_disease
+		var/list/data = list("viruses" = list(F), "blood_color" = "#A10808")
+		reagents.add_reagent("blood", disease_amount, data)
 
 /obj/item/reagent_containers/ex_act()
 	if(reagents)

--- a/code/modules/reagents/reagent_containers/iv_bag.dm
+++ b/code/modules/reagents/reagent_containers/iv_bag.dm
@@ -182,9 +182,9 @@
 
 
 /obj/item/reagent_containers/iv_bag/blood/random/Initialize()
+	. = ..()
 	blood_type = pick("A+", "A-", "B+", "B-", "O+", "O-")
 	blood_species = pick("Human", "Diona", "Drask", "Grey", "Kidan", "Tajaran", "Vulpkanin", "Skrell", "Unathi", "Nian", "Vox", "Wryn")
-	return ..()
 
 /obj/item/reagent_containers/iv_bag/blood/APlus
 	blood_type = "A+"


### PR DESCRIPTION
## Changes:
bug: fix runtime when calling `GenerateCure` proc for disease before `chemical_reagents_list` initialization
bug: fix runtime in `GenerateCure` caused by trying get the element from `advance_cures` list by float index
bug: fix `chemical_reactions_list` generation

