### PR TITLE
FEAT: Return rat pull kitchen items and food

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -315,6 +315,14 @@
 	mob_size = MOB_SIZE_SMALL
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/mouse = 2)
 
+/mob/living/simple_animal/mouse/rat/pull_constraint(atom/movable/AM, show_message = FALSE)
+	if(istype(AM, /obj/item/reagent_containers)) //Food, drinks, pills
+		return TRUE
+	if(istype(AM, /obj/item/kitchen)) //Stop hurting cook with kitchen knife and forks
+		return TRUE
+	if(show_message)
+		to_chat(src, "<span class='warning'>Вы не можете ухватиться за этот предмет.</span>")
+	return FALSE
 
 /mob/living/simple_animal/mouse/rat/color_pick()
 	if(!mouse_color)


### PR DESCRIPTION
## Описание
Возвращаем возможность крысам таскать еду с контейнерами, а также ножи и кухонные принадлежности, аля вилок и ложек.
Крысы по прежнему не могут больше таскать всякие мышелочки, капканы и прочие предметы которые ДЕЙСТВИТЕЛЬНО могли бы повлиять на геймплей где-то помимо кухни или испортить собственную поимку.
На крыс по прежнему действуют ограничения по размерам. Они не смогут таскать контейнеры, еду и кухонные принадлежности больше их по размеру.

## Ссылка на предложение/Причина создания ПР
То, что предназначалось для старого СС220 после авоутов, но я не успел туда создать ПР.

## Демонстрация изменений
![hamsters-knife](https://user-images.githubusercontent.com/41479614/234151180-992c9e30-18be-4088-8815-d9f339f12701.gif)
