### PR TITLE
fix: runtime and double windows on shuttles

### DIFF
--- a/_maps/map_files/cerestation/cerestation.dmm
+++ b/_maps/map_files/cerestation/cerestation.dmm
@@ -69465,7 +69465,6 @@
 /area/engine/chiefs_office)
 "pkt" = (
 /obj/effect/spawner/window/shuttle,
-/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/shuttle/arrival/station)
 "pkO" = (

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -19386,12 +19386,6 @@
 /obj/machinery/door/airlock/titanium,
 /turf/simulated/floor/shuttle,
 /area/shuttle/arrival/station)
-"aVY" = (
-/obj/structure/grille,
-/obj/structure/window/full/shuttle,
-/obj/structure/window/full/shuttle,
-/turf/simulated/floor/shuttle/plating,
-/area/shuttle/arrival/station)
 "aVZ" = (
 /obj/structure/grille,
 /obj/structure/window/full/shuttle,
@@ -108042,13 +108036,13 @@ aSf
 aSf
 aUk
 aSd
-aVY
+aVZ
 aXv
 aXs
 bba
 aXs
 aXs
-aVY
+aVZ
 aSd
 bgI
 aSf


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает лишние решётки у окон на шаттле Цере, т.к. спавнер окон шаттла сам спавнит их, при этом жалуясь на лишние решётки, удаляя их.

Убирает вторые окна в одном тайтле на шаттле Кибериады. 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
![Снимок экрана 2023-04-26 110915](https://user-images.githubusercontent.com/120549107/234559442-ad96fca2-cbc0-40e9-b0ed-64efdb7cd131.png)

![Снимок экрана 2023-04-26 134812](https://user-images.githubusercontent.com/120549107/234559390-47a6d88e-2f48-469a-961b-dbe03e45cd3a.png)

<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->
