### PR TITLE
Tweak: solonuke nerf

### DIFF
--- a/code/game/gamemodes/nuclear/lone.dm
+++ b/code/game/gamemodes/nuclear/lone.dm
@@ -1,4 +1,5 @@
-#define MIN_PLAYERS_FOR_LONEOP_EVENT 30
+#define MIN_PLAYERS_FOR_LONEOP_EVENT 40
+#define LONEOP_ANNOUNCE_DELAY 5 MINUTES
 
 /datum/event/operative
 	name = "Оперативник-одиночка"
@@ -74,6 +75,9 @@
 
 	return TRUE
 
+/datum/event/operative/proc/announce_loneop()
+	GLOB.event_announcement.Announce("Сканерами дальнего действия обнаружена активность на орбите станции, приближается неизвестный корабль.", "ВНИМАНИЕ: НЕИЗВЕСТНЫЙ КОРАБЛЬ.", 'sound/misc/announce_dig.ogg')
+
 
 /datum/event/operative/start()
 	processing = FALSE
@@ -82,5 +86,8 @@
 		return
 	if(!make_operative())
 		message_admins("Lone operative event failed to start. Not enough ghosts, nuke spawn points or nuke bombs.")
+		return
+	addtimer(CALLBACK(src, .proc/announce_loneop), LONEOP_ANNOUNCE_DELAY)
 
 #undef MIN_PLAYERS_FOR_LONEOP_EVENT
+#undef LONEOP_ANNOUNCE_DELAY


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Увеличивает минимальное число игроков для ивента.
Теперь есть анонс через 5 минут после начала ивента.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

