### PR TITLE
FIX: Cheaper paintkits

### DIFF
--- a/code/game/mecha/paintkits.dm
+++ b/code/game/mecha/paintkits.dm
@@ -21,7 +21,7 @@
 	new_name = "APLU \"Titan's Fist\""
 	new_desc = "This ordinary mining Ripley has been customized to look like a unit of the Titans Fist."
 	new_icon = "titan"
-	allowed_types = list("ripley")
+	allowed_types = list("ripley", "firefighter")
 
 /obj/item/paintkit/ripley_mercenary
 	name = "APLU \"Strike the Earth!\" customisation kit"
@@ -32,7 +32,7 @@
 	new_name = "APLU \"Strike the Earth!\""
 	new_desc = "Looks like an over worked, under maintained Ripley with some horrific damage."
 	new_icon = "earth"
-	allowed_types = list("ripley")
+	allowed_types = list("ripley", "firefighter")
 
 /obj/item/paintkit/gygax_syndie
 	name = "Syndicate Gygax customisation kit"
@@ -62,7 +62,7 @@
 	new_name = "APLU \"Firestarter\""
 	new_desc = "A standard APLU exosuit with stylish orange flame decals."
 	new_icon = "ripley_flames_red"
-	allowed_types = list("ripley")
+	allowed_types = list("ripley", "firefighter")
 
 /obj/item/paintkit/firefighter_Hauler
 	name = "APLU \"Hauler\" customisation kit"
@@ -72,7 +72,7 @@
 	new_name = "APLU \"Hauler\""
 	new_desc = "An old engineering exosuit. For lovers of classics."
 	new_icon = "hauler"
-	allowed_types = list( "firefighter")
+	allowed_types = list("ripley", "firefighter")
 
 /obj/item/paintkit/durand_shire
 	name = "Durand \"Shire\" modification kit"
@@ -92,7 +92,7 @@
 	new_name = "APLU \"Zairjah\""
 	new_desc = "A mining mecha of custom design, a closed cockpit with powerloader appendages."
 	new_icon = "ripley_zairjah"
-	allowed_types = list("firefighter")
+	allowed_types = list("ripley", "firefighter")
 
 /obj/item/paintkit/firefighter_combat
 	name = "APLU \"Combat Ripley\" customisation kit"
@@ -102,7 +102,7 @@
 	new_name = "APLU \"Combat Ripley\""
 	new_desc = "Wait a second, why does his equipment slots spark so dangerously?"
 	new_icon = "combatripley"
-	allowed_types = list("firefighter")
+	allowed_types = list("ripley", "firefighter")
 
 /obj/item/paintkit/firefighter_Reaper
 	name = "APLU \"Reaper\" customisation kit"
@@ -112,7 +112,7 @@
 	new_name = "APLU \"Reaper\""
 	new_desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA D- Stop, it's just a painted firefighter."
 	new_icon = "deathripley"
-	allowed_types = list("firefighter")
+	allowed_types = list("ripley", "firefighter")
 
 /obj/item/paintkit/odysseus_hermes
 	name = "Odysseus \"Hermes\" customisation kit"
@@ -182,7 +182,7 @@
 	new_name = "Aluminizer"
 	new_desc = "Did you just painted your Ripley white? It looks good."
 	new_icon = "aluminizer"
-	allowed_types = list("firefighter")
+	allowed_types = list("ripley", "firefighter")
 
 /obj/item/paintkit/odysseus_death
 	name = "Odysseus \"Reaper\" customisation kit"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -1594,95 +1594,95 @@
 	build_path = /obj/item/borg/upgrade/syndie_rcd
 	category = list("Syndicate")
 
-//new paintkits
+//Paintkits
 /datum/design/paint_ripley_titan
 	name = "APLU \"Titan's Fist\" customisation kit"
 	id = "p_titan"
 	build_type = MECHFAB
-	req_tech = list("combat" = 5, "engineering" = 7, "materials" = 5, "programming" = 6)
+	req_tech = list("combat" = 5, "engineering" = 5, "materials" = 5, "programming" = 5)
 	build_path = /obj/item/paintkit/ripley_titansfist
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 500
-	category = list("Ripley")
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
+	category = list("Ripley", "Firefighter")
 
 /datum/design/paint_ripley_earth
 	name = "APLU \"Strike the Earth!\" customisation kit"
 	id = "p_earth"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "engineering" = 7, "materials" = 5, "programming" = 6)
+	req_tech = list("combat" = 5, "engineering" = 5, "materials" = 5, "programming" = 5)
 	build_path = /obj/item/paintkit/ripley_mercenary
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 500
-	category = list("Ripley")
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
+	category = list("Ripley", "Firefighter")
 
 /datum/design/paint_ripley_red
 	name = "APLU \"Firestarter\" customisation kit"
 	id = "p_red"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 7, "materials" = 7, "toxins" = 6)
+	req_tech = list("engineering" = 5, "materials" = 5, "toxins" = 5)
 	build_path = /obj/item/paintkit/ripley_red
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 300
-	category = list("Ripley")
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
+	category = list("Ripley", "Firefighter")
 
 /datum/design/paint_firefighter_hauler
 	name = "APLU \"Hauler\" customisation kit"
 	id = "p_hauler"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 7, "materials" = 7, "programming" = 6)
+	req_tech = list("engineering" = 5, "materials" = 5, "programming" = 5)
 	build_path = /obj/item/paintkit/firefighter_Hauler
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 500
-	category = list("Firefighter")
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
+	category = list("Ripley", "Firefighter")
 
 /datum/design/paint_firefighter_zairjah
 	name = "APLU \"Zairjah\" customisation kit"
 	id = "p_zairjah"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 7, "materials" = 7, "programming" = 7, "toxins" = 5)
+	req_tech = list("engineering" = 5, "materials" = 5, "programming" = 5, "toxins" = 5)
 	build_path = /obj/item/paintkit/firefighter_zairjah
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 500
-	category = list("Firefighter")
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
+	category = list("Ripley", "Firefighter")
 
 /datum/design/paint_firefighter_combat
 	name = "APLU \"Combat Ripley\" customisation kit"
 	id = "p_combat"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "engineering" = 7, "materials" = 7, "programming" = 6)
+	req_tech = list("combat" = 5, "engineering" = 5, "materials" = 5, "programming" = 5)
 	build_path = /obj/item/paintkit/firefighter_combat
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 400
-	category = list("Firefighter")
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
+	category = list("Ripley", "Firefighter")
 
 /datum/design/paint_firefighter_reaper
 	name = "APLU \"Reaper\" customisation kit"
 	id = "p_reaper"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "engineering" = 7, "materials" = 7, "programming" = 6,"toxins" = 7)
+	req_tech = list("combat" = 5, "engineering" = 5, "materials" = 5, "programming" = 5,"toxins" = 5)
 	build_path = /obj/item/paintkit/firefighter_Reaper
 	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
 	construction_time = 600
-	category = list("Firefighter")
+	category = list("Ripley", "Firefighter")
 
 /datum/design/paint_firefighter_aluminizer
 	name = "APLU \"Aluminizer\" customisation kit"
 	id = "p_aluminizer"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 7, "materials" = 7, "programming" = 5,"toxins" = 5)
+	req_tech = list("engineering" = 5, "materials" = 5, "programming" = 5,"toxins" = 5)
 	build_path = /obj/item/paintkit/firefighter_aluminizer
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 400
-	category = list("Firefighter")
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
+	category = list("Ripley", "Firefighter")
 
 /datum/design/paint_gygax_black
 	name = "Syndicate Gygax customisation kit"
 	id = "p_blackgygax"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "engineering" = 6, "materials" = 7, "programming" = 6, "syndicate" = 3)
+	req_tech = list("combat" = 6, "engineering" = 5, "materials" = 6, "programming" = 5, "syndicate" = 3)
 	build_path = /obj/item/paintkit/gygax_syndie
 	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 700
+	construction_time = 300
 	category = list("Gygax")
 
 /datum/design/paint_gygax_alt
@@ -1691,85 +1691,85 @@
 	build_type = MECHFAB
 	req_tech = list("combat" = 4, "engineering" = 5, "materials" = 5, "programming" = 4)
 	build_path = /obj/item/paintkit/gygax_alt
-	materials = list(MAT_METAL=20000, MAT_DIAMOND=1000, MAT_URANIUM= 1000)
-	construction_time = 400
+	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
+	construction_time = 300
 	category = list("Gygax")
 
 /datum/design/paint_gygax_pobeda
 	name = "Gygax \"Pobeda\" customisation kit"
 	id = "p_pobedagygax"
 	build_type = MECHFAB
-	req_tech = list("combat" = 6, "engineering" = 5, "materials" = 5, "programming" = 7)
+	req_tech = list("combat" = 5, "engineering" = 4, "materials" = 4, "programming" = 6)
 	build_path = /obj/item/paintkit/gygax_pobeda
 	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 700
+	construction_time = 300
 	category = list("Gygax")
 
 /datum/design/paint_gygax_white
 	name = "White Gygax customisation kit"
 	id = "p_whitegygax"
 	build_type = MECHFAB
-	req_tech = list("biotech" = 5, "engineering" = 5, "materials" = 6, "programming" = 4 )
+	req_tech = list("biotech" = 4, "engineering" = 4, "materials" = 5, "programming" = 3 )
 	build_path = /obj/item/paintkit/gygax_white
 	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 700
+	construction_time = 300
 	category = list("Gygax")
 
 /datum/design/paint_durand_shire
 	name = "Durand \"Shire\" modification kit"
 	id = "p_shire"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "engineering" = 7, "materials" = 7, "programming" = 7)
+	req_tech = list("combat" = 6, "engineering" = 6, "materials" = 6, "programming" = 6)
 	build_path = /obj/item/paintkit/durand_shire
-	materials = list(MAT_METAL=60000, MAT_DIAMOND=5000, MAT_URANIUM= 10000)
-	construction_time = 800
+	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 10000)
+	construction_time = 300
 	category = list("Durand")
 
 /datum/design/paint_durand_unathi
 	name = "Durand \"Kharn MK. IV\" customisation kit"
 	id = "p_unathi"
 	build_type = MECHFAB
-	req_tech = list("materials" = 7, "biotech" = 7)
+	req_tech = list("materials" = 6, "biotech" = 6)
 	build_path = /obj/item/paintkit/durand_unathi
 	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 600
+	construction_time = 300
 	category = list("Durand")
 
 /datum/design/paint_durand_soviet
 	name = "Durand \"Dollhouse\" customisation kit"
 	id = "p_soviet"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "engineering" = 7, "materials" = 7, "programming" = 7, "toxins" = 7)
+	req_tech = list("combat" = 6, "engineering" = 6, "materials" = 6, "programming" = 6, "toxins" = 6)
 	build_path = /obj/item/paintkit/durand_soviet
-	materials = list(MAT_METAL=60000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 700
+	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
+	construction_time = 300
 	category = list("Durand")
 
 /datum/design/paint_odysseus_hermes
 	name = "Odysseus \"Hermes\" customisation kit"
 	id = "p_hermes"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 6, "materials" = 6, "programming" = 7,"biotech" = 7)
+	req_tech = list("engineering" = 5, "materials" = 5, "programming" = 5,"biotech" = 5)
 	build_path = /obj/item/paintkit/odysseus_hermes
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 300
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
 	category = list("Odysseus")
 
 /datum/design/paint_odysseus_reaper
 	name = "Odysseus \"Reaper\" customisation kit"
 	id = "p_odyreaper"
 	build_type = MECHFAB
-	req_tech = list("combat" = 7, "engineering" = 7, "materials" = 7, "programming" = 6, "toxins" = 7)
+	req_tech = list("combat" = 6, "engineering" = 6, "materials" = 6, "programming" = 5, "toxins" = 6)
 	build_path = /obj/item/paintkit/odysseus_death
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 300
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 100
 	category = list("Odysseus")
 
 /datum/design/paint_gygax_medgax
 	name = "Gygax \"medgax\" customisation kit"
 	id = "p_medgax"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 6, "materials" = 6, "programming" = 7,"biotech" = 7, "toxins" = 7)
+	req_tech = list("engineering" = 5, "materials" = 5, "programming" = 6,"biotech" = 6, "toxins" = 6)
 	build_path = /obj/item/paintkit/gygax_medgax
 	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
 	construction_time = 300
@@ -1779,58 +1779,58 @@
 	name = "Clarke \"Orangey\" customisation kit"
 	id = "p_orangey"
 	build_type = MECHFAB
-	req_tech = list("engineering" = 5, "materials" = 6, "toxins" = 6)
+	req_tech = list("engineering" = 5, "materials" = 5, "toxins" = 5)
 	build_path = /obj/item/paintkit/clarke_orangey
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 400
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 200
 	category = list("Clarke")
 
 /datum/design/paint_clarke_spiderclarke
 	name = "Clarke \"Spiderclarke\" customisation kit"
 	id = "p_spiderclarke"
 	build_type = MECHFAB
-	req_tech = list("combat" = 4, "engineering" = 6, "materials" = 7, "toxins" = 7)
+	req_tech = list("combat" = 4, "engineering" = 5, "materials" = 6, "toxins" = 6)
 	build_path = /obj/item/paintkit/clarke_spiderclarke
-	materials = list(MAT_METAL=40000, MAT_DIAMOND=5000, MAT_URANIUM= 5000)
-	construction_time = 400
+	materials = list(MAT_METAL=20000, MAT_DIAMOND=2000, MAT_URANIUM= 2000)
+	construction_time = 200
 	category = list("Clarke")
 
 /datum/design/paint_phazon_imperion
 	name = "Phazon \"Imperion\" customisation kit"
 	id = "p_imperion"
 	build_type = MECHFAB
-	req_tech = list("bluespace" = 7, "engineering" = 7, "materials" = 7, "programming" = 7, "toxins" = 6)
+	req_tech = list("bluespace" = 6, "engineering" = 6, "materials" = 6, "programming" = 6, "toxins" = 5)
 	build_path = /obj/item/paintkit/phazon_imperion
 	materials = list(MAT_METAL=60000, MAT_DIAMOND=5000, MAT_BLUESPACE=6000)
-	construction_time = 600
+	construction_time = 400
 	category = list("Phazon")
 
 /datum/design/paint_phazon_janus
 	name = "Phazon \"Janus\" customisation kit"
 	id = "p_janus"
 	build_type = MECHFAB
-	req_tech = list("bluespace" = 7, "engineering" = 7, "materials" = 7, "programming" = 7, "toxins" = 6)
+	req_tech = list("bluespace" = 6, "engineering" = 6, "materials" = 6, "programming" = 6, "toxins" = 5)
 	build_path = /obj/item/paintkit/phazon_janus
 	materials = list(MAT_METAL=60000, MAT_DIAMOND=5000, MAT_BLUESPACE=6000)
-	construction_time = 600
+	construction_time = 400
 	category = list("Phazon")
 
 /datum/design/paint_phazon_plazmus
 	name = "Phazon \"Plazmus\" customisation kit"
 	id = "p_plazmus"
 	build_type = MECHFAB
-	req_tech = list("bluespace" = 7, "engineering" = 7, "materials" = 7, "toxins" = 6)
+	req_tech = list("bluespace" = 6, "engineering" = 6, "materials" = 6, "toxins" = 5)
 	build_path = /obj/item/paintkit/phazon_plazmus
 	materials = list(MAT_METAL=60000, MAT_DIAMOND=5000, MAT_PLASMA = 10000)
-	construction_time = 600
+	construction_time = 400
 	category = list("Phazon")
 
 /datum/design/paint_phazon_blanco
 	name = "Phazon \"Blanco\" customisation kit"
 	id = "p_blanco"
 	build_type = MECHFAB
-	req_tech = list("bluespace" = 7, "engineering" = 7, "materials" = 7, "toxins" = 6)
+	req_tech = list("bluespace" = 6, "engineering" = 6, "materials" = 6, "toxins" = 5)
 	build_path = /obj/item/paintkit/phazon_blanco
 	materials = list(MAT_METAL=60000, MAT_DIAMOND=5000, MAT_BLUESPACE=6000)
-	construction_time = 600
+	construction_time = 400
 	category = list("Phazon")


### PR DESCRIPTION
Удешевляет наклейки на мехов в цене, техах, скорости производства. 

-Все небоевые мехи "Кларк, Рипли, Огнеборец, Одиссей" получили порог технологий наклеек до 5 техов, чтобы они были доступны раундстартом, когда они собственно и делаются. 
-Стоимость наклеек для небоевых мехов снижена, чтобы можно было с первыми ресурсами их построить. Скорость производства снижена с овердохуя до 10-20 секунд. 
-Все наклейки, доступные рипли и огнеборцу, теперь доступны И рипли И огнеборцу, потому что это буквально один рескин другого..

-Наклейки остальных мехов получили удешевление по техам на 1, кроме синди гигакса, он все еще требует 3 нелегал. -Скорость производства стала фиксированной: 20 для гигакса, 30 для дюранда, 40 для фазона -Цена наклеек на боевые мехи практически не изменилась.

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Ссылка на предложение/Причина создания ПР
Обсуждено с АДРом и другими уважаемыми личностями, общее решение что наклейки сейчас полностью охуевшие по всем параметрам и их нужно сделать доступнее. Особенно Рипли. 7 техи, серьезно?! на стартовый мех?!
Топик:
https://discord.com/channels/1097181193939730453/1102005164942045274/1102005164942045274

## Демонстрация изменений
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
