### PR TITLE
false wall fix

### DIFF
--- a/code/modules/w_examine/descriptions/structures.dm
+++ b/code/modules/w_examine/descriptions/structures.dm
@@ -19,3 +19,7 @@
 	<br>\
 	Anyone with restraints, such as handcuffs, will not be able to unbuckle themselves. They must use the Resist button, or verb, to break free of \
 	the buckles, instead."
+	
+/obj/structure/falsewall
+	description_info = "You can deconstruct this by welding it, and then wrenching the girder.<br>\
+	You can build a wall by using metal sheets and making a girder, then adding more metal or plasteel."


### PR DESCRIPTION
Добавлена [Справка] к фальшстенам, чтобы она не отличалась от обычных стен



Описание
Теперь у фальшстен есть такая же [Справка] как и у обычных стен.

Причина создания ПР:
Фикс ошибки из канала баг-репорты
(https://discord.com/channels/1097181193939730453/1102226047061196861)
