### PR TITLE
Fix: Research closet rewrites contents

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -112,7 +112,7 @@
 	bust_open()
 	update_icon()
 
-/obj/structure/closet/secure_closet/research_reagents/populate_contents()
+/obj/structure/closet/secure_closet/research_reagents/broken/populate_contents()
 	new /obj/item/reagent_containers/glass/bottle/reagent/hydrogen(src)
 	new /obj/item/reagent_containers/glass/bottle/reagent/phosphorus(src)
 	new /obj/item/reagent_containers/glass/bottle/reagent/iodine(src)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Устраняет проблему вызванную перезаписью контента шкафа химиков РнД ПРом
https://github.com/ss220club/Paradise/pull/122

## Ссылка на предложение/Причина создания ПР
Багрепорт

## Демонстрация изменений
Стало
![image](https://github.com/ss220club/Paradise/assets/20109643/80594b4e-8f90-411a-86f2-41a534bb05b5)

Было
![image](https://github.com/ss220club/Paradise/assets/20109643/10673410-74bd-49c5-99cf-8c89d93da507)
