### PR TITLE
fix: Sibyl lockboxes

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -39,7 +39,6 @@
 	l_pocket = /obj/item/lighter/zippo/hos
 	suit_store = /obj/item/gun/energy/gun/sibyl
 	pda = /obj/item/pda/heads/hos
-	l_hand = /obj/item/storage/lockbox/sibyl_system_mod
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1,
 		/obj/item/melee/classic_baton/telescopic = 1
@@ -87,7 +86,6 @@
 	l_pocket = /obj/item/flash
 	suit_store = /obj/item/gun/energy/dominator/sibyl
 	pda = /obj/item/pda/warden
-	l_hand = /obj/item/storage/lockbox/sibyl_system_mod
 	backpack_contents = list(
 		/obj/item/restraints/handcuffs = 1
 	)

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -113,6 +113,7 @@
 	new /obj/item/megaphone(src)	//added here deleted on maps
 	new /obj/item/reagent_containers/food/drinks/flask(src)
 	new /obj/item/storage/garmentbag/hos(src)
+	new /obj/item/storage/lockbox/sibyl_system_mod //added here deleted from roundstart hand
 
 /obj/structure/closet/secure_closet/warden
 	name = "warden's locker"
@@ -146,6 +147,7 @@
 	new /obj/item/gun/projectile/automatic/pistol/sp8(src)
 	new /obj/item/ammo_box/magazine/sp8(src)
 	new /obj/item/ammo_box/magazine/sp8(src)
+	new /obj/item/storage/lockbox/sibyl_system_mod(src) //added here deleted from roundstart hand
 
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Убирает раундстартовые кейсы с сибилами у Вардена и ГСБ, перемещает их им в ящики.
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Ссылка на предложение/Причина создания ПР
Отсутствие кейсов с сибилами, если нет кого-либо из вышеперечисленных на смене.
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
![image](https://github.com/ss220club/Paradise/assets/69762909/835dfd46-d484-4e61-a008-20b199b8bc97)
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
