### PR TITLE
FIX: Seed Storage visual bug

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -378,7 +378,7 @@
 	name = "\improper Seed Storage"
 	desc = "When you need seeds fast!"
 	icon = 'icons/obj/machines/vending.dmi'
-	icon_state = "seeds"
+	icon_state = "smartfridge"
 
 /obj/machinery/smartfridge/seeds/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Багфиксит исчезновение Seed Storage.
## Ссылка на предложение/Причина создания ПР
Изменение icon_state позволит быстро и не запариваясь решить проблему с исчезающим спрайтом Seed Storage. Возникала эта проблема из-за того, что при добавлении семян в Seed Storage его icon_state из-за родительского smartfridge менялся с seeds на seeds1, seeds2 и seeds3 по мере увеличения кол-ва семян. Такая же проблема может возникнуть и в других дочерних от smartfridge машинах.
Ссылка на багрепорт: https://discord.com/channels/1097181193939730453/1112370458923372624/1112370458923372624
![image](https://github.com/ss220club/Paradise/assets/109545437/e2022000-cbc8-48ba-8096-3f122b90b8d0)
![image](https://github.com/ss220club/Paradise/assets/109545437/9ed71ea2-53ba-434a-b987-ddc104b56789)

