### PR TITLE
Ген непробивемости

### DIFF
--- a/code/game/gamemodes/spaceninja/ninja/outfit.dm
+++ b/code/game/gamemodes/spaceninja/ninja/outfit.dm
@@ -25,4 +25,5 @@
 		ninja_suit.n_backpack = ninja.back
 		if(istype(ninja.belt, belt))
 			ninja_suit.energyKatana = ninja.belt
+	ninja.dna.species.species_traits = PIERCEIMMUNE
 


### PR DESCRIPTION

<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->
Добавляет ген непробиваемости ниндзяге. Теперь его нельзя монкефицировать с помощью стаб мутагея и крови монке.

НО! Заодно, теперь ниндзя не может хилиться мендерами и использовать на себе шприцы. Любые шприцы.
## Причина создания ПР
У недо-разумистов достаточно распространена тактика монкефикации ниндзи, для получения с него всего лута и лёгкого его убийства. Этот ПР это фиксит.
