### PR TITLE
Fix: Mech fab output direction

### DIFF
--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -25056,7 +25056,9 @@
 /turf/simulated/floor/plasteel,
 /area/bridge)
 "bpD" = (
-/obj/machinery/mecha_part_fabricator,
+/obj/machinery/mecha_part_fabricator{
+	dir = 1
+	},
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/south,
 /turf/simulated/floor/plasteel{
@@ -100107,7 +100109,9 @@
 "xyG" = (
 /obj/effect/decal/warning_stripes/yellow/hollow,
 /obj/effect/decal/warning_stripes/south,
-/obj/machinery/mecha_part_fabricator,
+/obj/machinery/mecha_part_fabricator{
+	dir = 1
+	},
 /turf/simulated/floor/plasteel{
 	dir = 8;
 	icon_state = "neutralfull"

--- a/_maps/map_files/cyberiad/cyberiad.dmm
+++ b/_maps/map_files/cyberiad/cyberiad.dmm
@@ -77460,6 +77460,13 @@
 /obj/effect/decal/cleanable/dust,
 /turf/simulated/floor/wood,
 /area/security/permabrig)
+"mMQ" = (
+/obj/effect/decal/warning_stripes/yellow,
+/obj/structure/reagent_dispensers/oil,
+/turf/simulated/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/misc_lab)
 "mMY" = (
 /obj/structure/chair/stool{
 	dir = 4
@@ -81249,7 +81256,6 @@
 	},
 /area/library)
 "oEh" = (
-/obj/item/twohanded/required/kirbyplants,
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -24
@@ -81258,6 +81264,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/structure/reagent_dispensers/oil,
 /turf/simulated/floor/plasteel{
 	dir = 6;
 	icon_state = "whiteyellow"
@@ -148865,7 +148872,7 @@ eAx
 cDw
 jAo
 cDw
-cDw
+ueA
 cAP
 cJK
 cKZ
@@ -149379,7 +149386,7 @@ nFN
 cFS
 lvA
 cDw
-ueA
+mMQ
 cAP
 cBR
 cBR

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -213,12 +213,12 @@
   */
 /obj/machinery/mecha_part_fabricator/proc/build_design_timer_finish(datum/design/D, list/final_cost)
 	// Spawn the item (in a lockbox if restricted) OR mob (e.g. IRC body)
-	var/atom/A = new D.build_path(get_step(src, SOUTH))
+	var/atom/A = new D.build_path(get_step(src, dir))
 	if(istype(A, /obj/item))
 		var/obj/item/I = A
 		I.materials = final_cost
 		if(D.locked)
-			var/obj/item/storage/lockbox/research/large/L = new(get_step(src, SOUTH))
+			var/obj/item/storage/lockbox/research/large/L = new(get_step(src, dir))
 			I.forceMove(L)
 			L.name += " ([I.name])"
 			L.origin_tech = I.origin_tech

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -169,7 +169,11 @@
   */
 /obj/machinery/mecha_part_fabricator/proc/build_design(datum/design/D)
 	. = FALSE
+	var/turf_to_print_on = (get_step(src, dir))
 	if(!local_designs.known_designs[D.id] || !(D.build_type & allowed_design_types))
+		return
+	if(iswallturf(turf_to_print_on))
+		atom_say("Не могу печатать - там стена")
 		return
 	if(being_built)
 		atom_say("Ошибка: уже в процессе производства!")


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе ваш текст может не отобразиться. -->
<!-- В Contributing.MD вы можете найти некоторые рекомендации к оформлению пулл-реквеста. -->

## Описание
Теперь можно самому решать в какую сторону с мех фаба будут выплёвываться детали.
По умолчанию выплёвываются вниз.
Добавил масла для ЕРП химикам меда и РнД
За помощь спасибо @Gaxeer 
<!-- Опишите, что делает ваш ПР. Документировать каждую деталь не требуется, просто укажите основные изменения. -->

## Причина создания ПР
Мехфаб выплёвывал в стену в новом робо...
<!-- Здесь оставьте ссылку на сообщение в #отчеты-по-предложениям, чтобы подтвердить, что ваше предложение одобрено. Либо укажите, почему этот ПР должен пройти без предложки. -->
<!-- Пример ссылки: https://discord.com/channels/617003227182792704/755125334097133628/ID-сообщения -->

## Демонстрация изменений
Верьте на слово
<!-- Здесь вы можете показать изменения внешне, к примеру новые спрайты, звуки или изменения карты. Или написать, что именно изменилось для игроков. Этот пункт полностью опционален и его можно удалить. -->
